### PR TITLE
Cleaned up transaction type parameter

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -3,11 +3,9 @@ package driver
 
 import (
 	"errors"
-	"flag"
 	"fmt"
 	"log"
 	neturl "net/url"
-	"os"
 	"strings"
 
 	"github.com/fedyakin/migrate/driver/bash"
@@ -16,8 +14,6 @@ import (
 	"github.com/fedyakin/migrate/driver/postgres"
 	"github.com/fedyakin/migrate/file"
 )
-
-var transactionType = flag.String("txn", "PerFile", "")
 
 type TxnType int
 
@@ -54,7 +50,7 @@ type Driver interface {
 }
 
 // New returns Driver and calls Initialize on it
-func New(url string) (Driver, error) {
+func New(url string, txnType TxnType) (Driver, error) {
 	u, err := neturl.Parse(url)
 	if err != nil {
 		return nil, err
@@ -62,12 +58,6 @@ func New(url string) (Driver, error) {
 
 	switch u.Scheme {
 	case "postgres":
-		txnType, err := getTxnType()
-		if err != nil {
-			fmt.Println(err.Error())
-			os.Exit(1)
-		}
-
 		// For postgres we support multiple transaction strategies
 		var d Driver
 		switch txnType {
@@ -130,8 +120,8 @@ func verifyFilenameExtension(driverName string, d Driver) {
 
 // getTxnType returns the transaction behavior specified, or an error for unknown
 // or undefined behaviors
-func getTxnType() (TxnType, error) {
-	switch strings.ToLower(*transactionType) {
+func GetTxnType(txnType string) (TxnType, error) {
+	switch strings.ToLower(txnType) {
 	case "none":
 		return TxnNone, nil
 
@@ -142,5 +132,5 @@ func getTxnType() (TxnType, error) {
 		return TxnPerFile, nil
 	}
 
-	return TxnNone, fmt.Errorf("Unknown transaction type requested: '%s'", *transactionType)
+	return TxnNone, fmt.Errorf("Unknown transaction type requested: '%s'", txnType)
 }

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -1,11 +1,9 @@
 package driver
 
-import (
-	"testing"
-)
+import "testing"
 
 func TestNew(t *testing.T) {
-	if _, err := New("unknown://url"); err == nil {
+	if _, err := New("unknown://url", TxnPerFile); err == nil {
 		t.Error("no error although driver unknown")
 	}
 }

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -18,8 +18,8 @@ import (
 )
 
 // Up applies all available migrations
-func Up(pipe chan interface{}, url, migrationsPath string) {
-	d, files, version, err := initDriverAndReadMigrationFilesAndGetVersion(url, migrationsPath)
+func Up(pipe chan interface{}, url, migrationsPath string, txnType driver.TxnType) {
+	d, files, version, err := initDriverAndReadMigrationFilesAndGetVersion(url, migrationsPath, txnType)
 	if err != nil {
 		go pipep.Close(pipe, err)
 		return
@@ -57,16 +57,16 @@ func Up(pipe chan interface{}, url, migrationsPath string) {
 }
 
 // UpSync is synchronous version of Up
-func UpSync(url, migrationsPath string) (err []error, ok bool) {
+func UpSync(url, migrationsPath string, txnType driver.TxnType) (err []error, ok bool) {
 	pipe := pipep.New()
-	go Up(pipe, url, migrationsPath)
+	go Up(pipe, url, migrationsPath, txnType)
 	err = pipep.ReadErrors(pipe)
 	return err, len(err) == 0
 }
 
 // Down rolls back all migrations
-func Down(pipe chan interface{}, url, migrationsPath string) {
-	d, files, version, err := initDriverAndReadMigrationFilesAndGetVersion(url, migrationsPath)
+func Down(pipe chan interface{}, url, migrationsPath string, txnType driver.TxnType) {
+	d, files, version, err := initDriverAndReadMigrationFilesAndGetVersion(url, migrationsPath, txnType)
 	if err != nil {
 		go pipep.Close(pipe, err)
 		return
@@ -104,56 +104,56 @@ func Down(pipe chan interface{}, url, migrationsPath string) {
 }
 
 // DownSync is synchronous version of Down
-func DownSync(url, migrationsPath string) (err []error, ok bool) {
+func DownSync(url, migrationsPath string, txnType driver.TxnType) (err []error, ok bool) {
 	pipe := pipep.New()
-	go Down(pipe, url, migrationsPath)
+	go Down(pipe, url, migrationsPath, txnType)
 	err = pipep.ReadErrors(pipe)
 	return err, len(err) == 0
 }
 
 // Redo rolls back the most recently applied migration, then runs it again.
-func Redo(pipe chan interface{}, url, migrationsPath string) {
+func Redo(pipe chan interface{}, url, migrationsPath string, txnType driver.TxnType) {
 	pipe1 := pipep.New()
-	go Migrate(pipe1, url, migrationsPath, -1)
+	go Migrate(pipe1, url, migrationsPath, -1, txnType)
 	if ok := pipep.WaitAndRedirect(pipe1, pipe, handleInterrupts()); !ok {
 		go pipep.Close(pipe, nil)
 		return
 	} else {
-		go Migrate(pipe, url, migrationsPath, +1)
+		go Migrate(pipe, url, migrationsPath, +1, txnType)
 	}
 }
 
 // RedoSync is synchronous version of Redo
-func RedoSync(url, migrationsPath string) (err []error, ok bool) {
+func RedoSync(url, migrationsPath string, txnType driver.TxnType) (err []error, ok bool) {
 	pipe := pipep.New()
-	go Redo(pipe, url, migrationsPath)
+	go Redo(pipe, url, migrationsPath, txnType)
 	err = pipep.ReadErrors(pipe)
 	return err, len(err) == 0
 }
 
 // Reset runs the down and up migration function
-func Reset(pipe chan interface{}, url, migrationsPath string) {
+func Reset(pipe chan interface{}, url, migrationsPath string, txnType driver.TxnType) {
 	pipe1 := pipep.New()
-	go Down(pipe1, url, migrationsPath)
+	go Down(pipe1, url, migrationsPath, txnType)
 	if ok := pipep.WaitAndRedirect(pipe1, pipe, handleInterrupts()); !ok {
 		go pipep.Close(pipe, nil)
 		return
 	} else {
-		go Up(pipe, url, migrationsPath)
+		go Up(pipe, url, migrationsPath, txnType)
 	}
 }
 
 // ResetSync is synchronous version of Reset
-func ResetSync(url, migrationsPath string) (err []error, ok bool) {
+func ResetSync(url, migrationsPath string, txnType driver.TxnType) (err []error, ok bool) {
 	pipe := pipep.New()
-	go Reset(pipe, url, migrationsPath)
+	go Reset(pipe, url, migrationsPath, txnType)
 	err = pipep.ReadErrors(pipe)
 	return err, len(err) == 0
 }
 
 // Migrate applies relative +n/-n migrations
-func Migrate(pipe chan interface{}, url, migrationsPath string, relativeN int) {
-	d, files, version, err := initDriverAndReadMigrationFilesAndGetVersion(url, migrationsPath)
+func Migrate(pipe chan interface{}, url, migrationsPath string, relativeN int, txnType driver.TxnType) {
+	d, files, version, err := initDriverAndReadMigrationFilesAndGetVersion(url, migrationsPath, txnType)
 	if err != nil {
 		go pipep.Close(pipe, err)
 		return
@@ -190,16 +190,16 @@ func Migrate(pipe chan interface{}, url, migrationsPath string, relativeN int) {
 }
 
 // MigrateSync is synchronous version of Migrate
-func MigrateSync(url, migrationsPath string, relativeN int) (err []error, ok bool) {
+func MigrateSync(url, migrationsPath string, relativeN int, txnType driver.TxnType) (err []error, ok bool) {
 	pipe := pipep.New()
-	go Migrate(pipe, url, migrationsPath, relativeN)
+	go Migrate(pipe, url, migrationsPath, relativeN, txnType)
 	err = pipep.ReadErrors(pipe)
 	return err, len(err) == 0
 }
 
 // Version returns the current migration version
-func Version(url, migrationsPath string) (version uint64, err error) {
-	d, err := driver.New(url)
+func Version(url, migrationsPath string, txnType driver.TxnType) (version uint64, err error) {
+	d, err := driver.New(url, txnType)
 	if err != nil {
 		return 0, err
 	}
@@ -207,8 +207,8 @@ func Version(url, migrationsPath string) (version uint64, err error) {
 }
 
 // Create creates new migration files on disk
-func Create(url, migrationsPath, name string) (*file.MigrationFile, error) {
-	d, err := driver.New(url)
+func Create(url, migrationsPath, name string, txnType driver.TxnType) (*file.MigrationFile, error) {
+	d, err := driver.New(url, txnType)
 	if err != nil {
 		return nil, err
 	}
@@ -263,8 +263,8 @@ func Create(url, migrationsPath, name string) (*file.MigrationFile, error) {
 
 // initDriverAndReadMigrationFilesAndGetVersion is a small helper
 // function that is common to most of the migration funcs
-func initDriverAndReadMigrationFilesAndGetVersion(url, migrationsPath string) (driver.Driver, *file.MigrationFiles, uint64, error) {
-	d, err := driver.New(url)
+func initDriverAndReadMigrationFilesAndGetVersion(url, migrationsPath string, txnType driver.TxnType) (driver.Driver, *file.MigrationFiles, uint64, error) {
+	d, err := driver.New(url, txnType)
 	if err != nil {
 		return nil, nil, 0, err
 	}

--- a/migrate/migrate_test.go
+++ b/migrate/migrate_test.go
@@ -3,6 +3,8 @@ package migrate
 import (
 	"io/ioutil"
 	"testing"
+
+	"github.com/fedyakin/migrate/driver"
 )
 
 // Add Driver URLs here to test basic Up, Down, .. functions.
@@ -18,10 +20,10 @@ func TestCreate(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if _, err := Create(driverUrl, tmpdir, "test_migration"); err != nil {
+		if _, err := Create(driverUrl, tmpdir, "test_migration", driver.TxnPerFile); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := Create(driverUrl, tmpdir, "another migration"); err != nil {
+		if _, err := Create(driverUrl, tmpdir, "another migration", driver.TxnPerFile); err != nil {
 			t.Fatal(err)
 		}
 
@@ -59,14 +61,14 @@ func TestReset(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		Create(driverUrl, tmpdir, "migration1")
-		Create(driverUrl, tmpdir, "migration2")
+		Create(driverUrl, tmpdir, "migration1", driver.TxnPerFile)
+		Create(driverUrl, tmpdir, "migration2", driver.TxnPerFile)
 
-		errs, ok := ResetSync(driverUrl, tmpdir)
+		errs, ok := ResetSync(driverUrl, tmpdir, driver.TxnPerFile)
 		if !ok {
 			t.Fatal(errs)
 		}
-		version, err := Version(driverUrl, tmpdir)
+		version, err := Version(driverUrl, tmpdir, driver.TxnPerFile)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -84,14 +86,14 @@ func TestDown(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		Create(driverUrl, tmpdir, "migration1")
-		Create(driverUrl, tmpdir, "migration2")
+		Create(driverUrl, tmpdir, "migration1", driver.TxnPerFile)
+		Create(driverUrl, tmpdir, "migration2", driver.TxnPerFile)
 
-		errs, ok := ResetSync(driverUrl, tmpdir)
+		errs, ok := ResetSync(driverUrl, tmpdir, driver.TxnPerFile)
 		if !ok {
 			t.Fatal(errs)
 		}
-		version, err := Version(driverUrl, tmpdir)
+		version, err := Version(driverUrl, tmpdir, driver.TxnPerFile)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -99,11 +101,11 @@ func TestDown(t *testing.T) {
 			t.Fatalf("Expected version 2, got %v", version)
 		}
 
-		errs, ok = DownSync(driverUrl, tmpdir)
+		errs, ok = DownSync(driverUrl, tmpdir, driver.TxnPerFile)
 		if !ok {
 			t.Fatal(errs)
 		}
-		version, err = Version(driverUrl, tmpdir)
+		version, err = Version(driverUrl, tmpdir, driver.TxnPerFile)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -121,14 +123,14 @@ func TestUp(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		Create(driverUrl, tmpdir, "migration1")
-		Create(driverUrl, tmpdir, "migration2")
+		Create(driverUrl, tmpdir, "migration1", driver.TxnPerFile)
+		Create(driverUrl, tmpdir, "migration2", driver.TxnPerFile)
 
-		errs, ok := DownSync(driverUrl, tmpdir)
+		errs, ok := DownSync(driverUrl, tmpdir, driver.TxnPerFile)
 		if !ok {
 			t.Fatal(errs)
 		}
-		version, err := Version(driverUrl, tmpdir)
+		version, err := Version(driverUrl, tmpdir, driver.TxnPerFile)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -136,11 +138,11 @@ func TestUp(t *testing.T) {
 			t.Fatalf("Expected version 0, got %v", version)
 		}
 
-		errs, ok = UpSync(driverUrl, tmpdir)
+		errs, ok = UpSync(driverUrl, tmpdir, driver.TxnPerFile)
 		if !ok {
 			t.Fatal(errs)
 		}
-		version, err = Version(driverUrl, tmpdir)
+		version, err = Version(driverUrl, tmpdir, driver.TxnPerFile)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -158,14 +160,14 @@ func TestRedo(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		Create(driverUrl, tmpdir, "migration1")
-		Create(driverUrl, tmpdir, "migration2")
+		Create(driverUrl, tmpdir, "migration1", driver.TxnPerFile)
+		Create(driverUrl, tmpdir, "migration2", driver.TxnPerFile)
 
-		errs, ok := ResetSync(driverUrl, tmpdir)
+		errs, ok := ResetSync(driverUrl, tmpdir, driver.TxnPerFile)
 		if !ok {
 			t.Fatal(errs)
 		}
-		version, err := Version(driverUrl, tmpdir)
+		version, err := Version(driverUrl, tmpdir, driver.TxnPerFile)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -173,11 +175,11 @@ func TestRedo(t *testing.T) {
 			t.Fatalf("Expected version 2, got %v", version)
 		}
 
-		errs, ok = RedoSync(driverUrl, tmpdir)
+		errs, ok = RedoSync(driverUrl, tmpdir, driver.TxnPerFile)
 		if !ok {
 			t.Fatal(errs)
 		}
-		version, err = Version(driverUrl, tmpdir)
+		version, err = Version(driverUrl, tmpdir, driver.TxnPerFile)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -195,14 +197,14 @@ func TestMigrate(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		Create(driverUrl, tmpdir, "migration1")
-		Create(driverUrl, tmpdir, "migration2")
+		Create(driverUrl, tmpdir, "migration1", driver.TxnPerFile)
+		Create(driverUrl, tmpdir, "migration2", driver.TxnPerFile)
 
-		errs, ok := ResetSync(driverUrl, tmpdir)
+		errs, ok := ResetSync(driverUrl, tmpdir, driver.TxnPerFile)
 		if !ok {
 			t.Fatal(errs)
 		}
-		version, err := Version(driverUrl, tmpdir)
+		version, err := Version(driverUrl, tmpdir, driver.TxnPerFile)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -210,11 +212,11 @@ func TestMigrate(t *testing.T) {
 			t.Fatalf("Expected version 2, got %v", version)
 		}
 
-		errs, ok = MigrateSync(driverUrl, tmpdir, -2)
+		errs, ok = MigrateSync(driverUrl, tmpdir, -2, driver.TxnPerFile)
 		if !ok {
 			t.Fatal(errs)
 		}
-		version, err = Version(driverUrl, tmpdir)
+		version, err = Version(driverUrl, tmpdir, driver.TxnPerFile)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -222,11 +224,11 @@ func TestMigrate(t *testing.T) {
 			t.Fatalf("Expected version 0, got %v", version)
 		}
 
-		errs, ok = MigrateSync(driverUrl, tmpdir, +1)
+		errs, ok = MigrateSync(driverUrl, tmpdir, +1, driver.TxnPerFile)
 		if !ok {
 			t.Fatal(errs)
 		}
-		version, err = Version(driverUrl, tmpdir)
+		version, err = Version(driverUrl, tmpdir, driver.TxnPerFile)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Moved transaction type flag to main package, and require it to be passed at driver creation.  This allows the transaction type to be specified cleanly when used at import time.
