### PR TITLE
Duplicate file versions is an error

### DIFF
--- a/file/file.go
+++ b/file/file.go
@@ -181,9 +181,18 @@ func ReadMigrationFiles(path string, filenameRegex *regexp.Regexp) (files Migrat
 		always   bool
 	}
 	tmpFiles := make([]*tmpFile, 0)
+	tmpFileMap := map[uint64]map[direction.Direction]tmpFile{}
 	for _, file := range ioFiles {
 		version, name, d, always, err := parseFilenameSchema(file.Name(), filenameRegex)
 		if err == nil {
+			if _, ok := tmpFileMap[version]; !ok {
+				tmpFileMap[version] = map[direction.Direction]tmpFile{}
+			}
+			if existing, ok := tmpFileMap[version][d]; !ok {
+				tmpFileMap[version][d] = tmpFile{version: version, name: name, filename: file.Name(), d: d}
+			} else {
+				return nil, fmt.Errorf("duplicate migration file version %d : %q and %q", version, existing.filename, file.Name())
+			}
 			tmpFiles = append(tmpFiles, &tmpFile{version, name, file.Name(), d, always})
 		}
 	}


### PR DESCRIPTION
Just manually replicated the fix.  I opted to not pull it from master, because other changes required reimplementing parts of the transaction control support.  I did the work in a different branch, but it is some risk for no reward.